### PR TITLE
Fix expired discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,5 @@ Version 3, 29 June 2007 <br />
 @ModernPwner - CVE (cicuta_virosa)<br />
 @Brandonplank - Sandbox r/w priviliges <br />
 
-Join us -> https://discord.gg/ey6FAabR46
+Join us -> https://discord.gg/BtcJKXYkWu
 


### PR DESCRIPTION
The old link said "This invite may be expired, or you might not have permission to join." The new link was set to never expire and has no limit.